### PR TITLE
Update tests to drop network dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "sls": "npm run build && npm run build --prefix example",
     "test": "npm run eslint && npm run jest"
   },
-  "version": "0.1.14"
+  "version": "0.1.15"
 }


### PR DESCRIPTION
Rework local plugin test to simply write to package.json instead of using npm install / uninstall.