### PR TITLE
Deps check fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "sls": "npm run build && npm run build --prefix example",
     "test": "npm run eslint && npm run jest"
   },
-  "version": "0.1.15"
+  "version": "0.1.16"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -99,8 +99,8 @@ class ServerlessIOpipePlugin {
     options(val);
   }
   checkForLocalPlugin(){
-    const {dependencies, devDependencies} = this.package;
-    if (dependencies['serverless-plugin-iopipe'] || devDependencies && devDependencies['serverless-plugin-iopipe']){
+    const {dependencies = {}, devDependencies = {}} = this.package;
+    if (dependencies['serverless-plugin-iopipe'] || devDependencies['serverless-plugin-iopipe']){
       if (!options().preferLocal){
         track({
           action: 'plugin-installed-locally'


### PR DESCRIPTION
- Ensure both `dependencies` and `devDependencies` are objects before plugin check.
- Bump ver
Thanks to @yonahforst for initial issue!