### PR TITLE
Display source handler errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+handlerCode.js

--- a/example/handlers/syntaxError.js
+++ b/example/handlers/syntaxError.js
@@ -1,0 +1,6 @@
+const uuid = require('uuid');
+
+module.exports.handler = (event, context) => {
+  const foo = {
+  context.succeed(response);
+};

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -36,6 +36,8 @@ functions:
     handler: handlers/noModule.handler
   excluded:
     handler: handlers/excluded.handler
+  syntaxError:
+    handler: handlers/syntaxError.handler
   es5Named:
     handler: handlers/es5Named.handler
   python:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "scripts": {
     "build": "NODE_ENV=production npm run folder && npm run webpack && npm run uglify && npm run copy",
     "babel": "./node_modules/babel-cli/bin/babel.js src --out-dir dist --ignore **/*.test.js,**/__mocks__/**",
-    "eslint": "eslint src/**",
+    "eslint": "eslint src",
     "eslintFix": "npm run eslint -- --fix",
     "copy": "node src/util/copyDist",
     "folder": "rm -rf dist && mkdir dist",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "jest": "jest",
     "jestUpdateSnapshot": "jest --updateSnapshot",
     "prepublish": "npm run build",
-    "sls": "npm run build && npm run build --prefix example",
-    "slsDeploy": "npm run build && npm run deploy --prefix example",
+    "sls": "LOCAL_PLUGIN=true npm run build && npm run build --prefix example",
+    "slsDeploy": "LOCAL_PLUGIN=true npm run build && npm run deploy --prefix example",
     "test": "npm run eslint && npm run jest"
   },
   "version": "0.2.1"

--- a/src/__mocks__/sls.js
+++ b/src/__mocks__/sls.js
@@ -300,6 +300,11 @@ export default {
         "events": [],
         "name": "sls-iopipe-prod-noModule"
       },
+      "syntaxError": {
+        "handler": "handlers/syntaxError.handler",
+        "events": [],
+        "name": "sls-iopipe-prod-syntaxError"
+      },
       "excluded": {
         "handler": "handlers/excluded.handler",
         "events": [],

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,10 +3,60 @@
 exports[`Can create iopipe handler file 1`] = `
 "const iopipe = require('iopipe')({token: 'TEST_TOKEN'});
 
-exports['simple'] = iopipe(require('./handlers/simple').handler);
-exports['multiple'] = iopipe(require('./handlers/multiple').handler);
-exports['multipleDifferentHandler'] = iopipe(require('./handlers/multiple').differentNameHandler);
-exports['es5'] = iopipe(require('./handlers/es5').handler);
-exports['multiple-dots-in-name'] = iopipe(require('./handlers/multiple.dots.in.name').handler);
-exports['noModule'] = iopipe(require('./handlers/noModule').handler);"
+exports['simple'] = function attemptSimple0(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/simple').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['multiple'] = function attemptMultiple1(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/multiple').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['multipleDifferentHandler'] = function attemptMultipleDifferentHandler2(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/multiple').differentNameHandler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['es5'] = function attemptEs53(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/es5').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['multiple-dots-in-name'] = function attemptMultipleDotsInName4(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/multiple.dots.in.name').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['noModule'] = function attemptNoModule5(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/noModule').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+
+exports['syntaxError'] = function attemptSyntaxError6(event, context, callback) {
+  try {
+    return iopipe(require('./handlers/syntaxError').handler)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+"
 `;

--- a/src/handlerCode.js
+++ b/src/handlerCode.js
@@ -1,0 +1,7 @@
+exports['EXPORT_NAME'] = function FUNCTION_NAME(event, context, callback) {
+  try {
+    return iopipe(require('./RELATIVE_PATH').METHOD)(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -257,8 +257,15 @@ class ServerlessIOpipePlugin {
     debug('Creating file');
     const iopipeInclude = `const iopipe = require('iopipe')({token: '${options().token}'});`;
     const funcContents = _.chain(this.funcs)
-      .map(obj => {
-        return `exports['${obj.name}'] = iopipe(require('./${obj.relativePath}').${obj.method});`;
+      .map((obj, index) => {
+        return `exports['${obj.name}'] = function ${_.camelCase('attempt-' + obj.name)}${index}(event, context, callback) {
+  try {
+    return iopipe(require('./${obj.relativePath}').${obj.method})(event, context, callback);
+  } catch (err) {
+    throw err;
+  }
+};
+`;
       })
       .join('\n')
       .value();

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,10 @@ function outputHandlerCode(obj = {}, index) {
   const { name, relativePath, method } = obj;
   const fnName = _.camelCase('attempt-' + name) + index;
   return _.chain(handlerCode)
-    .replace(/EXPORT_NAME/, name)
-    .replace(/FUNCTION_NAME/, fnName)
-    .replace(/RELATIVE_PATH/, relativePath)
-    .replace(/METHOD/, method)
+    .replace(/EXPORT_NAME/g, name)
+    .replace(/FUNCTION_NAME/g, fnName)
+    .replace(/RELATIVE_PATH/g, relativePath)
+    .replace(/METHOD/g, method)
     .value();
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ class ServerlessIOpipePlugin {
           const key = arr[0];
           const obj = arr[1];
           const handlerArr = _.isString(obj.handler) ? obj.handler.split('.') : [];
-          const relativePath = handlerArr.length > 1 ? handlerArr.slice(0, -1).join('.') : handlerArr[0];
+          const relativePath = handlerArr.slice(0, -1).join('.');
           const path = `${servicePath}/${relativePath}.js`;
           return _.assign({}, obj, {
             method: _.last(handlerArr),

--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,11 @@ function createDebugger(suffix) {
 function outputHandlerCode(obj = {}, index) {
   const { name, relativePath, method } = obj;
   const fnName = _.camelCase('attempt-' + name) + index;
-  return _.chain(handlerCode)
+  return handlerCode
     .replace(/EXPORT_NAME/g, name)
     .replace(/FUNCTION_NAME/g, fnName)
     .replace(/RELATIVE_PATH/g, relativePath)
-    .replace(/METHOD/g, method)
-    .value();
+    .replace(/METHOD/g, method);
 }
 
 class ServerlessIOpipePlugin {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -205,6 +205,28 @@ test('Handler file works', async () => {
   expect(simpleReturn.statusCode).toBe(200);
 });
 
+test('Syntax error handler is accounted for', async () => {
+  const {syntaxError} = require(path.join(prefix, 'iopipe-handlers.js'));
+  expect(syntaxError).toBeInstanceOf(Function);
+  const syntaxErrorPromise = new Promise((resolve, reject) => {
+    // run the handler with dummy event / context
+    syntaxError({}, {
+      succeed: resolve,
+      fail: reject
+    });
+  });
+  let returnValue = undefined;
+  let thrownError = undefined;
+  try {
+    returnValue = await syntaxErrorPromise;
+  } catch (err){
+    thrownError = err;
+  }
+  expect(returnValue).toBeUndefined();
+  expect(thrownError.message).toMatch(/Unexpected\stoken,\s/);
+  expect(thrownError.message).toMatch(/\/example\/handlers\/syntaxError\.js/);
+});
+
 test('Cleans up', () => {
   Plugin.finish();
   const files = readdirSync(prefix);


### PR DESCRIPTION
Use `try / catch` to allow original errors (syntax or otherwise) to bubble to the top of the error stack.
- Fixes #23 