### PR TITLE
feat(iopipe handler files): output multiple iopipe handler files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 testProjects/*/package-lock.json
 testProjects/*/yarn.lock
 iopipe-handlers.js
+*-iopipe.js

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "cosmiconfig": "^3",
     "debug": "^2.6.8",
+    "del": "^3.0.0",
     "fs-extra": "^5.0.0",
     "lodash": "^4.17.4",
     "universal-analytics": "^0.4.13",
@@ -91,6 +92,7 @@
     "testProjects/*/node_modules",
     "testProjects/*/.serverless",
     "testProjects/*/.serverless_plugins",
-    "syntaxError.js"
+    "syntaxError.js",
+    "*iopipe.js"
   ]
 }

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,70 +3,10 @@
 exports[`Can create iopipe handler file 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"TEST_TOKEN\\"});
 
-exports['simple'] = function attemptSimple0(event, context, callback) {
+exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
       return require('./handlers/simple').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['multiple'] = function attemptMultiple1(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['multipleDifferentHandler'] = function attemptMultipleDifferentHandler2(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple').differentNameHandler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['es5'] = function attemptEs53(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/es5').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['multiple-dots-in-name'] = function attemptMultipleDotsInName4(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple.dots.in.name').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['noModule'] = function attemptNoModule5(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/noModule').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['syntaxError'] = function attemptSyntaxError6(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/syntaxError').handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -69,7 +69,7 @@ test('Plugin has proper executeable methods', () => {
     'upgradeLib',
     'checkToken',
     'getFuncs',
-    'createFile',
+    'createFiles',
     'assignHandlers',
     'finish'
   ].forEach(str => {
@@ -228,49 +228,18 @@ test('Gets funcs', () => {
 
 test('Can create iopipe handler file', () => {
   Plugin.getOptions({ token: 'TEST_TOKEN' });
-  Plugin.createFile();
-  const file = readFileSync(path.join(prefix, 'iopipe-handlers.js'), 'utf8');
+  Plugin.createFiles();
+  const file = readFileSync(path.join(prefix, 'simple-0-iopipe.js'), 'utf8');
   expect(file).toBeDefined();
   expect(file).toMatchSnapshot();
 });
 
 test('Agent instantiation is blank if no iopipeToken in custom section of serverless.yml', () => {
   Plugin.getOptions({ token: '' });
-  const file = Plugin.createFile();
+  Plugin.createFiles();
+  const file = readFileSync(path.join(prefix, 'simple-0-iopipe.js'), 'utf8');
   expect(file).toBeDefined();
   expect(file.split('\n')[0]).toEqual("const iopipe = require('iopipe')();");
-});
-
-test('Handler file works', async () => {
-  const { simple } = require(path.join(prefix, 'iopipe-handlers.js'));
-  expect(simple).toBeInstanceOf(Function);
-  const simplePromise = new Promise((resolve, reject) => {
-    // run the handler with dummy event / context
-    simple(
-      {},
-      {
-        succeed: resolve,
-        fail: reject
-      }
-    );
-  });
-  const simpleReturn = await simplePromise;
-  expect(simpleReturn).toBeInstanceOf(Object);
-  expect(simpleReturn.statusCode).toBe(200);
-});
-
-test('Syntax error handler is accounted for', async () => {
-  // need to include token for lib not to simply return the user func
-  process.env.IOPIPE_TOKEN = 'test_token';
-  const { syntaxError } = require(path.join(prefix, 'iopipe-handlers.js'));
-  expect(syntaxError).toBeInstanceOf(Function);
-  const returnValue = await new Promise(resolve => {
-    syntaxError({}, {}, resolve);
-  });
-  expect(returnValue.message).toMatch(/Unexpected\stoken,\s/);
-  expect(returnValue.message).toMatch(
-    /\/testProjects\/default\/handlers\/syntaxError\.js/
-  );
 });
 
 test('Cleans up', () => {

--- a/testProjects/cosmi/__snapshots__/index.test.js.snap
+++ b/testProjects/cosmi/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`Generated file requires plugin and includes plugin inline 1`] = `
 require('@iopipe/trace');
 const iopipe = require('@iopipe/core')({\\"plugins\\":[\\"@iopipe/event-info\\",\\"@iopipe/trace\\"],\\"token\\":\\"test-token\\"});
 
-exports['simple'] = function attemptSimple0(event, context, callback) {
+exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
       return require('./handlers/simple').handler(evt, ctx, cb);

--- a/testProjects/cosmi/index.test.js
+++ b/testProjects/cosmi/index.test.js
@@ -7,7 +7,7 @@ test('Generated file requires plugin and includes plugin inline', async () => {
   expect(1).toBe(1);
   const handlerFile = _.find(
     zip.getEntries(),
-    entry => entry.entryName === 'iopipe-handlers.js'
+    entry => entry.entryName === 'simple-0-iopipe.js'
   );
   const fileContents = handlerFile.getData().toString('utf8');
   expect(fileContents).toMatchSnapshot();

--- a/testProjects/default/__snapshots__/index.test.js.snap
+++ b/testProjects/default/__snapshots__/index.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Generated file requires plugin and includes plugin inline 1`] = `
+exports[`Generated files require plugin, include plugin inline, and export original handler 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
-exports['simple'] = function attemptSimple0(event, context, callback) {
+exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
       return require('./handlers/simple').handler(evt, ctx, cb);
@@ -12,71 +12,31 @@ exports['simple'] = function attemptSimple0(event, context, callback) {
     throw err;
   }
 };
+"
+`;
 
-exports['multiple'] = function attemptMultiple1(event, context, callback) {
+exports[`Generated files require plugin, include plugin inline, and export original handler 2`] = `
+"const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
+
+exports['nameMismatch'] = function attemptNameMismatch(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple').handler(evt, ctx, cb);
+      return require('./handlers/differentName').wow(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;
   }
 };
+"
+`;
 
-exports['multipleDifferentHandler'] = function attemptMultipleDifferentHandler2(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple').differentNameHandler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
+exports[`Generated files require plugin, include plugin inline, and export original handler 3`] = `
+"const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
-exports['es5'] = function attemptEs53(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/es5').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['multiple-dots-in-name'] = function attemptMultipleDotsInName4(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/multiple.dots.in.name').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['noModule'] = function attemptNoModule5(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/noModule').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['syntaxError'] = function attemptSyntaxError6(event, context, callback) {
+exports['syntaxError'] = function attemptSyntaxError(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
       return require('./handlers/syntaxError').handler(evt, ctx, cb);
-    })(event, context, callback);
-  } catch (err) {
-    throw err;
-  }
-};
-
-exports['es5Named'] = function attemptEs5Named7(event, context, callback) {
-  try {
-    return iopipe((evt, ctx, cb) => {
-      return require('./handlers/es5Named').handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/testProjects/default/handlers/differentName.js
+++ b/testProjects/default/handlers/differentName.js
@@ -1,0 +1,3 @@
+module.exports.wow = (event, context) => {
+  context.succeed(301);
+};

--- a/testProjects/default/index.test.js
+++ b/testProjects/default/index.test.js
@@ -1,24 +1,51 @@
 /*eslint-disable import/no-extraneous-dependencies*/
+/*eslint-disable no-eval*/
 import _ from 'lodash';
 import AdmZip from 'adm-zip';
 
 process.env.IOPIPE_TOKEN = 'test_token';
 
-test('Generated file requires plugin and includes plugin inline', async () => {
+test('Generated files require plugin, include plugin inline, and export original handler', async () => {
   const zip = new AdmZip('./.serverless/sls-unit-test-default.zip');
-  expect(1).toBe(1);
-  const handlerFile = _.find(
+
+  // simple handler
+  const simpleFile = _.find(
     zip.getEntries(),
-    entry => entry.entryName === 'iopipe-handlers.js'
+    entry => entry.entryName === 'simple-0-iopipe.js'
   );
-  const fileContents = handlerFile.getData().toString('utf8');
-  expect(fileContents).toMatchSnapshot();
-  /*eslint-disable no-eval*/
-  eval(fileContents);
+  const simpleFileContents = simpleFile.getData().toString('utf8');
+  expect(simpleFileContents).toMatchSnapshot();
+
+  eval(simpleFileContents);
   const result = await new Promise(succeed => {
     exports.simple({}, { succeed });
   });
   expect(result.statusCode).toEqual(200);
+
+  // name mismatch handler
+  const nameMismatch = _.find(
+    zip.getEntries(),
+    entry => entry.entryName === 'nameMismatch-8-iopipe.js'
+  );
+  const nameMismatchContents = nameMismatch.getData().toString('utf8');
+  expect(nameMismatchContents).toMatchSnapshot();
+
+  eval(nameMismatchContents);
+  const nameMismatchResult = await new Promise(succeed => {
+    exports.nameMismatch({}, { succeed });
+  });
+  expect(nameMismatchResult).toEqual(301);
+
+  // syntax error handler
+  const syntaxErrorFile = _.find(
+    zip.getEntries(),
+    entry => entry.entryName === 'syntaxError-6-iopipe.js'
+  );
+  const syntaxErrorResultFileContents = syntaxErrorFile
+    .getData()
+    .toString('utf8');
+  expect(syntaxErrorResultFileContents).toMatchSnapshot();
+  eval(syntaxErrorResultFileContents);
   const syntaxErrorResult = await new Promise(succeed => {
     exports.syntaxError({}, {}, succeed);
   });

--- a/testProjects/default/serverless.yml
+++ b/testProjects/default/serverless.yml
@@ -43,3 +43,5 @@ functions:
   python:
     handler: python/main.longRunning
     runtime: python2.7
+  nameMismatch:
+    handler: handlers/differentName.wow

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,6 +2522,17 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
By creating a new iopipe handler file per function, the plugin can support advanced use cases such
as webpack individual packaging.

fix #64 

- Create new iopipe handler file per function
- Introduce `del` pkg for glob file removal
- Remove a couple of end-to-end tests from `index.test.js` as they are fully covered in the `default` project tests
- Add name mismatch handler/test to ensure that any handler/file naming paradigm is supported.