### PR TITLE
fix(finish function): use force option for del command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -393,7 +393,7 @@ class ServerlessIOpipePlugin {
       'Successfully wrapped Node.js functions with IOpipe, cleaning up.'
     );
     debug(`Removing ${this.handlerFileName}.js`);
-    await del(join(this.originalServicePath, '*-iopipe.js'));
+    await del(join(this.originalServicePath, '*-iopipe.js'), { force: true });
     this.track({
       action: 'finish'
     })


### PR DESCRIPTION
Force can be used here due to the glob pattern of *-iopipe.js which would protect against unintended
results

fix #68