### PR TITLE
feat(serverless-offline): add support for serverless-offline plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,10 @@ You're set! The plugin will run during an `sls deploy` or during `sls invoke loc
 Check out an [example here](https://github.com/iopipe/serverless-plugin-iopipe/blob/master/example/serverless.yml).
 
 # How Does it Work?
-`serverless-plugin-iopipe` outputs a file that imports and wraps the function handlers defined in `serverless.yml` with IOpipe so you don't have to. It allows you to deploy and upgrade multiple functions simultaneously.
+`serverless-plugin-iopipe` outputs files that import and wrap the function handlers defined in `serverless.yml` with IOpipe so you don't have to. It allows you to deploy and upgrade multiple functions simultaneously.
+
+# Commands
+- `sls iopipe clean` This command cleans up your project folder of extraneous `*-iopipe.js` files if needed. This can be useful when using the [serverless-offline](https://github.com/dherault/serverless-offline) plugin.
 
 # Options
 Beyond the required $IOPIPE_TOKEN environment variable, some options can be set [in the "custom" config](https://serverless.com/framework/docs/providers/aws/guide/plugins#installing-plugins) in `serverless.yml`. [See Example](https://github.com/iopipe/serverless-plugin-iopipe/blob/master/example/serverless.yml)
@@ -85,8 +88,10 @@ By default, the plugin sends _anonymized_, non-identifying usage statistics to G
     - serverless-plugin-iopipe
     - serverless-webpack
   ```
+- Does this work with [serverless-offline](https://github.com/dherault/serverless-offline)?
+  - Yes, list `serverless-plugin-iopipe` first before any other plugins in `serverless.yml`.
 - Can I use IOpipe plugins?
-  - Yes, you can specify iopipe plugins through your [package.json file, or an iopipe.rc file](https://github.com/iopipe/iopipe-js-core#packagejson-configuration). You will have to make sure those plugins are installed into node_modules.
+  - Yes, you can specify iopipe plugins through your [package.json file, or an iopipe.rc file](https://github.com/iopipe/iopipe-js-core#packagejson-configuration). Ensure those plugins are installed into your node_modules folder (yarn or npm).
 
 ## Known Issues
 - If you have lambda functions that are already wrapped by iopipe via code, you may experience unexpected results. Remove the iopipe wrapping code from those handlers.

--- a/src/index.js
+++ b/src/index.js
@@ -110,15 +110,24 @@ class ServerlessIOpipePlugin {
       iopipe: {
         usage:
           "Automatically wraps your function handlers in IOpipe, so you don't have to.",
-        lifecycleEvents: ['run']
+        lifecycleEvents: ['run', 'clean'],
+        commands: {
+          clean: {
+            usage: 'Cleans up extra IOpipe files if necessary',
+            lifecycleEvents: ['init']
+          }
+        }
       }
     };
     this.hooks = {
+      'iopipe:run': this.greeting.bind(this),
       'before:package:createDeploymentArtifacts': this.run.bind(this),
       'before:invoke:local:invoke': this.run.bind(this),
+      'before:offline:start:init': this.run.bind(this),
+      'before:step-functions-offline:start': this.run.bind(this),
       'after:package:createDeploymentArtifacts': this.finish.bind(this),
       'after:invoke:local:invoke': this.finish.bind(this),
-      'iopipe:run': this.greeting.bind(this)
+      'iopipe:clean:init': this.finish.bind(this)
     };
   }
   getOptions(obj = this.options) {
@@ -389,9 +398,7 @@ class ServerlessIOpipePlugin {
   }
   async finish() {
     const debug = createDebugger('finish');
-    this.log(
-      'Successfully wrapped Node.js functions with IOpipe, cleaning up.'
-    );
+    this.log('Cleaning up extraneous IOpipe files');
     debug(`Removing ${this.handlerFileName}.js`);
     await del(join(this.originalServicePath, '*-iopipe.js'));
     this.track({

--- a/testProjects/cosmi/package.json
+++ b/testProjects/cosmi/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "@iopipe/core": "^1.8.0",
     "@iopipe/event-info": "^0.1.1",
-    "@iopipe/trace": "^0.3.0",
-    "iopipe": "1.9.0"
+    "@iopipe/trace": "^0.3.0"
   },
   "scripts": {
     "build": "SLS_DEBUG=* IOPIPE_TOKEN='test-token' node ../../node_modules/serverless/bin/serverless package",

--- a/testProjects/cosmi/package.json
+++ b/testProjects/cosmi/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@iopipe/core": "^1.8.0",
     "@iopipe/event-info": "^0.1.1",
-    "@iopipe/trace": "^0.3.0"
+    "@iopipe/trace": "^0.3.0",
+    "iopipe": "1.9.0"
   },
   "scripts": {
     "build": "SLS_DEBUG=* IOPIPE_TOKEN='test-token' node ../../node_modules/serverless/bin/serverless package",

--- a/testProjects/offline/handlers/index.js
+++ b/testProjects/offline/handlers/index.js
@@ -1,0 +1,12 @@
+exports.handler = (event, context) => {
+  let body = { success: true };
+  const params = event.queryStringParameters || {};
+  const { fail } = params;
+  if (!context.iopipe || fail) {
+    body = { err: 'No iopipe object found on context' };
+  }
+  return context.succeed({
+    statusCode: 200,
+    body: JSON.stringify(body)
+  });
+};

--- a/testProjects/offline/package.json
+++ b/testProjects/offline/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sls-unit-test-local-invoke",
+  "version": "0.0.0-test",
+  "description": "",
+  "main": "handler.js",
+  "dependencies": {
+    "@iopipe/iopipe": "^1.5.0",
+    "cross-spawn": "^6.0.5",
+    "got": "^8.3.0",
+    "serverless-offline": "^3.20.2"
+  },
+  "scripts": {
+    "build": "echo 'No need to build'",
+    "start": "SLS_DEBUG=* IOPIPE_TOKEN=test_token node ../../node_modules/serverless/bin/serverless offline start",
+    "test": "IOPIPE_TOKEN=test_token node test"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {}
+}

--- a/testProjects/offline/serverless.yml
+++ b/testProjects/offline/serverless.yml
@@ -1,0 +1,21 @@
+service: sls-iopipe-offline-test
+provider:
+  name: aws
+  runtime: nodejs6.10
+  stage: prod
+  region: us-west-2
+environment:
+  IOPIPE_TOKEN: ${env:IOPIPE_TOKEN}
+plugins:
+  - serverless-plugin-iopipe/index.js
+  - serverless-offline
+functions:
+  index:
+    handler: handlers/index.handler
+    events:
+      - http:
+          path: /
+          method: get
+custom:
+  serverless-offline:
+    port: 4982

--- a/testProjects/offline/test.js
+++ b/testProjects/offline/test.js
@@ -20,7 +20,7 @@ async function run() {
 const offlineChild = spawn('npm', ['start'], {
   stdio: 'inherit',
   // http://azimi.me/2014/12/31/kill-child_process-node-js.html
-  detatched: true
+  detached: true
 });
 
 setTimeout(async () => {
@@ -30,7 +30,7 @@ setTimeout(async () => {
   } catch (e) {
     err = e;
   }
-  process.kill(offlineChild.pid, 'SIGINT');
+  process.kill(-offlineChild.pid, 'SIGINT');
   if (err) {
     throw err;
   }

--- a/testProjects/offline/test.js
+++ b/testProjects/offline/test.js
@@ -1,0 +1,37 @@
+const gotLib = require('got');
+const spawn = require('cross-spawn');
+
+const got = str => gotLib(str, { json: true });
+const BASE = `http://localhost:4982`;
+
+async function run() {
+  // make sure that the error state works too
+  const { body: { err } } = await got(`${BASE}?fail=true`);
+  if (err !== 'No iopipe object found on context') {
+    throw new Error(err || 'Wrong');
+  }
+  const { body: { success } } = await got(BASE);
+  if (success !== true) {
+    throw new Error('No success msg');
+  }
+  return true;
+}
+
+const offlineChild = spawn('npm', ['start'], {
+  stdio: 'inherit',
+  // http://azimi.me/2014/12/31/kill-child_process-node-js.html
+  detatched: true
+});
+
+setTimeout(async () => {
+  let err;
+  try {
+    await run();
+  } catch (e) {
+    err = e;
+  }
+  process.kill(offlineChild.pid, 'SIGINT');
+  if (err) {
+    throw err;
+  }
+}, process.env.OFFLINE_STARTUP_MILLIS || 5000);


### PR DESCRIPTION
Use serverless-offline hooks for integration. Add new `iopipe clean` command as it is useful with
offline. Update docs. Streamline testProjects runner.

fix #70