### PR TITLE
fix(handler files): move require block outside of handler for best lambda cold start performance

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -4,9 +4,9 @@ exports[`Can create iopipe handler file 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"TEST_TOKEN\\"});
 
 let handler, handlerError;
-// automatically generated require statement by the plugin
-// aimed to provide syntax/type errors to the iopipe service
-// the original file is imported as text with capitalized tokens replaced
+// The following is an automatically generated require statement by the plugin,
+// aimed to provide syntax/type errors to the IOpipe service.
+// The original file is imported as text with capitalized tokens replaced.
 try {
   handler = require('../handlers/simple');
 } catch (err) {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -4,6 +4,9 @@ exports[`Can create iopipe handler file 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"TEST_TOKEN\\"});
 
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../handlers/simple');
 } catch (err) {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,10 +3,20 @@
 exports[`Can create iopipe handler file 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"TEST_TOKEN\\"});
 
+let handler, handlerError;
+try {
+  handler = require('../handlers/simple');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../handlers/simple').handler(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/src/handlerCode.js
+++ b/src/handlerCode.js
@@ -1,7 +1,17 @@
+let handler, handlerError;
+try {
+  handler = require('../RELATIVE_PATH');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['EXPORT_NAME'] = function FUNCTION_NAME(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../RELATIVE_PATH').METHOD(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.METHOD(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/src/handlerCode.js
+++ b/src/handlerCode.js
@@ -1,4 +1,7 @@
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../RELATIVE_PATH');
 } catch (err) {

--- a/testProjects/cosmi/__snapshots__/index.test.js.snap
+++ b/testProjects/cosmi/__snapshots__/index.test.js.snap
@@ -6,6 +6,9 @@ require('@iopipe/trace');
 const iopipe = require('@iopipe/core')({\\"plugins\\":[\\"@iopipe/event-info\\",\\"@iopipe/trace\\"],\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../handlers/simple');
 } catch (err) {

--- a/testProjects/cosmi/__snapshots__/index.test.js.snap
+++ b/testProjects/cosmi/__snapshots__/index.test.js.snap
@@ -6,9 +6,9 @@ require('@iopipe/trace');
 const iopipe = require('@iopipe/core')({\\"plugins\\":[\\"@iopipe/event-info\\",\\"@iopipe/trace\\"],\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
-// automatically generated require statement by the plugin
-// aimed to provide syntax/type errors to the iopipe service
-// the original file is imported as text with capitalized tokens replaced
+// The following is an automatically generated require statement by the plugin,
+// aimed to provide syntax/type errors to the IOpipe service.
+// The original file is imported as text with capitalized tokens replaced.
 try {
   handler = require('../handlers/simple');
 } catch (err) {

--- a/testProjects/cosmi/__snapshots__/index.test.js.snap
+++ b/testProjects/cosmi/__snapshots__/index.test.js.snap
@@ -5,10 +5,20 @@ exports[`Generated files requires plugin and includes plugin inline 1`] = `
 require('@iopipe/trace');
 const iopipe = require('@iopipe/core')({\\"plugins\\":[\\"@iopipe/event-info\\",\\"@iopipe/trace\\"],\\"token\\":\\"test-token\\"});
 
+let handler, handlerError;
+try {
+  handler = require('../handlers/simple');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../handlers/simple').handler(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/testProjects/default/__snapshots__/index.test.js.snap
+++ b/testProjects/default/__snapshots__/index.test.js.snap
@@ -3,10 +3,20 @@
 exports[`Generated files require plugin, include plugin inline, and export original handler 1`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
+let handler, handlerError;
+try {
+  handler = require('../handlers/simple');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['simple'] = function attemptSimple(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../handlers/simple').handler(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;
@@ -18,10 +28,20 @@ exports['simple'] = function attemptSimple(event, context, callback) {
 exports[`Generated files require plugin, include plugin inline, and export original handler 2`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
+let handler, handlerError;
+try {
+  handler = require('../handlers/differentName');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['nameMismatch'] = function attemptNameMismatch(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../handlers/differentName').wow(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.wow(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;
@@ -33,10 +53,20 @@ exports['nameMismatch'] = function attemptNameMismatch(event, context, callback)
 exports[`Generated files require plugin, include plugin inline, and export original handler 3`] = `
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
+let handler, handlerError;
+try {
+  handler = require('../handlers/syntaxError');
+} catch (err) {
+  handlerError = err;
+}
+
 exports['syntaxError'] = function attemptSyntaxError(event, context, callback) {
   try {
     return iopipe((evt, ctx, cb) => {
-      return require('../handlers/syntaxError').handler(evt, ctx, cb);
+      if (handlerError) {
+        return cb(handlerError);
+      }
+      return handler.handler(evt, ctx, cb);
     })(event, context, callback);
   } catch (err) {
     throw err;

--- a/testProjects/default/__snapshots__/index.test.js.snap
+++ b/testProjects/default/__snapshots__/index.test.js.snap
@@ -4,6 +4,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../handlers/simple');
 } catch (err) {
@@ -29,6 +32,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../handlers/differentName');
 } catch (err) {
@@ -54,6 +60,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
+// automatically generated require statement by the plugin
+// aimed to provide syntax/type errors to the iopipe service
+// the original file is imported as text with capitalized tokens replaced
 try {
   handler = require('../handlers/syntaxError');
 } catch (err) {

--- a/testProjects/default/__snapshots__/index.test.js.snap
+++ b/testProjects/default/__snapshots__/index.test.js.snap
@@ -4,9 +4,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
-// automatically generated require statement by the plugin
-// aimed to provide syntax/type errors to the iopipe service
-// the original file is imported as text with capitalized tokens replaced
+// The following is an automatically generated require statement by the plugin,
+// aimed to provide syntax/type errors to the IOpipe service.
+// The original file is imported as text with capitalized tokens replaced.
 try {
   handler = require('../handlers/simple');
 } catch (err) {
@@ -32,9 +32,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
-// automatically generated require statement by the plugin
-// aimed to provide syntax/type errors to the iopipe service
-// the original file is imported as text with capitalized tokens replaced
+// The following is an automatically generated require statement by the plugin,
+// aimed to provide syntax/type errors to the IOpipe service.
+// The original file is imported as text with capitalized tokens replaced.
 try {
   handler = require('../handlers/differentName');
 } catch (err) {
@@ -60,9 +60,9 @@ exports[`Generated files require plugin, include plugin inline, and export origi
 "const iopipe = require('iopipe')({\\"token\\":\\"test-token\\"});
 
 let handler, handlerError;
-// automatically generated require statement by the plugin
-// aimed to provide syntax/type errors to the iopipe service
-// the original file is imported as text with capitalized tokens replaced
+// The following is an automatically generated require statement by the plugin,
+// aimed to provide syntax/type errors to the IOpipe service.
+// The original file is imported as text with capitalized tokens replaced.
 try {
   handler = require('../handlers/syntaxError');
 } catch (err) {


### PR DESCRIPTION
By moving the require block outside of the handler, AWS can properly use performance enhancements on their side to optimize the cold start.

fix #77