### PR TITLE
fix(individual function deploy): use serverless function deploy hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -396,14 +396,14 @@ class ServerlessIOpipePlugin {
     const { inlineConfig } = this.getConfig();
     const { handlerDir } = this.getOptions();
     const iopipeInclude = `const iopipe = require('${this.getInstalledPackageName()}')(${inlineConfig});`;
-    this.funcs.forEach((func, index) => {
+    this.funcs.forEach(func => {
       const handler = outputHandlerCode(func);
       const contents = `${iopipeInclude}\n\n${handler}`;
       fs.ensureDirSync(join(this.originalServicePath, handlerDir));
       fs.writeFileSync(
         join(
           this.originalServicePath,
-          join(handlerDir, `${func.name}-${index}-iopipe.js`)
+          join(handlerDir, `${func.name}-iopipe.js`)
         ),
         contents
       );
@@ -413,11 +413,11 @@ class ServerlessIOpipePlugin {
     const debug = createDebugger('assignHandlers');
     debug('Assigning iopipe handlers to sls service');
     const { handlerDir } = this.getOptions();
-    this.funcs.forEach((obj, index) => {
+    this.funcs.forEach(obj => {
       _.set(
         this.sls.service.functions,
         `${obj.name}.handler`,
-        posix.join(handlerDir, `${obj.name}-${index}-iopipe.${obj.name}`)
+        posix.join(handlerDir, `${obj.name}-iopipe.${obj.name}`)
       );
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,7 @@ class ServerlessIOpipePlugin {
     this.hooks = {
       'iopipe:run': this.greeting.bind(this),
       'before:package:createDeploymentArtifacts': this.run.bind(this),
+      'before:deploy:function:packageFunction': this.run.bind(this),
       'before:invoke:local:invoke': this.run.bind(this),
       'before:offline:start:init': this.run.bind(this),
       'before:step-functions-offline:start': this.run.bind(this),

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -230,7 +230,7 @@ test('Can create iopipe handler file', () => {
   Plugin.getOptions({ token: 'TEST_TOKEN' });
   Plugin.createFiles();
   const file = readFileSync(
-    path.join(prefix, 'iopipe_handlers/simple-0-iopipe.js'),
+    path.join(prefix, 'iopipe_handlers/simple-iopipe.js'),
     'utf8'
   );
   expect(file).toBeDefined();
@@ -241,7 +241,7 @@ test('Agent instantiation only includes installMethod if no iopipeToken in custo
   Plugin.getOptions({ token: '' });
   Plugin.createFiles();
   const file = readFileSync(
-    path.join(prefix, 'iopipe_handlers/simple-0-iopipe.js'),
+    path.join(prefix, 'iopipe_handlers/simple-iopipe.js'),
     'utf8'
   );
   expect(file).toBeDefined();

--- a/testProjects/cosmi/index.test.js
+++ b/testProjects/cosmi/index.test.js
@@ -18,7 +18,7 @@ afterAll(() => {
 test('Generated files requires plugin and includes plugin inline', async () => {
   const simpleRes = await run({
     dir,
-    file: 'simple-0-iopipe.js'
+    file: 'simple-iopipe.js'
   });
   expect(simpleRes).toBe(200);
 });

--- a/testProjects/default/index.test.js
+++ b/testProjects/default/index.test.js
@@ -18,19 +18,19 @@ afterAll(() => {
 test('Generated files require plugin, include plugin inline, and export original handler', async () => {
   const simpleRes = await run({
     dir,
-    file: 'simple-0-iopipe.js'
+    file: 'simple-iopipe.js'
   });
   expect(simpleRes.statusCode).toBe(200);
 
   const nameMismatchRes = await run({
     dir,
-    file: 'nameMismatch-8-iopipe.js'
+    file: 'nameMismatch-iopipe.js'
   });
   expect(nameMismatchRes).toBe(301);
 
   const syntaxErrorRes = await run({
     dir,
-    file: 'syntaxError-6-iopipe.js'
+    file: 'syntaxError-iopipe.js'
   });
   expect(syntaxErrorRes.message).toMatch(/Unexpected\stoken,\s/);
 });


### PR DESCRIPTION
- Use individual function deploy hook, otherwise when deploying the handler is not wrapped.
- Remove index from naming scheme when generating files. If a user adds/removes new functions, the indices could change and a subsequent deploy could fail. Serverless disallows duplicate names in `serverless.yml` so this was an unnecessary guard. Users may need to do a full `sls deploy` if there is any issue with library's new version. (Although `sls deploy` was really the only feature supported anyway)

fix #84

Verified through end-to-end test with deploying a stack + single function